### PR TITLE
CI: use erlef/setup-beam on Linux with OTP 23, 24, 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 jobs:
   linux-ci:
     runs-on: ubuntu-20.04
+    name: Linux CI (OTP ${{matrix.otp}})
+    strategy:
+      matrix:
+        otp: ['25.2', '24.3', '23.3']
     steps:
       - name: Checkout
         uses: "actions/checkout@v2"
@@ -15,6 +19,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Install OTP
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          rebar3-version: '3.20.0'
       - name: Assemble eqwalizer.jar
         run: "cd eqwalizer; sbt assembly"
       - name: Assemble eqwalizer binary
@@ -26,8 +35,10 @@ jobs:
       - name: Add elp to path
         run: 'echo "$GITHUB_WORKSPACE/mini-elp/target/release" >> $GITHUB_PATH'
       - name: Test eqwalizer
+        if: matrix.otp != '23.3'
         run: 'cd eqwalizer && sbt test'
       - name: Upload eqwalizer.jar
+        if: matrix.otp == '25.2'
         uses: "actions/upload-artifact@v2"
         with:
           name: eqwalizer.jar
@@ -36,6 +47,7 @@ jobs:
     needs:
       - linux-ci
     runs-on: macos-latest
+    name: MacOS CI (OTP 25)
     steps:
       - name: Checkout
         uses: "actions/checkout@v2"
@@ -46,7 +58,7 @@ jobs:
           java: 'java11'
       - name: Install Native Image Plugin
         run: gu install native-image
-      - name: Install erlang + rebar3
+      - name: Install OTP + rebar3
         run: brew install erlang rebar3
       - name: Set up rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- mini-elp tests are running OK for all OTP versions
- uploading eqwalizer.jar once (when running with OTP 25)
- disabling (for now) eqwalizer tests against OTP 23 - as we have cases with `try/catch` which are not compatible with OTP 23 compiler