### PR TITLE
CI: support OTP 23 on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,12 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
-          rebar3-version: '3.20.0'
+          install-rebar: false
+          install-hex: false
+      - name: Install rebar3
+        run: "curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3 && chmod +x rebar3"
+      - name: "add rebar3 to path"
+        run: 'echo "$GITHUB_WORKSPACE/rebar3" >> $GITHUB_PATH'
       - name: Assemble eqwalizer.jar
         run: "cd eqwalizer; sbt assembly"
       - name: Assemble eqwalizer binary
@@ -54,7 +59,10 @@ jobs:
     needs:
       - linux-ci
     runs-on: macos-latest
-    name: MacOS CI (OTP 25)
+    name: MacOS CI (${{matrix.brew_erlang}})
+    strategy:
+      matrix:
+        brew_erlang: ['erlang@25', 'erlang@24', 'erlang@23']
     steps:
       - name: Checkout
         uses: "actions/checkout@v2"
@@ -65,8 +73,10 @@ jobs:
           java: 'java11'
       - name: Install Native Image Plugin
         run: gu install native-image
-      - name: Install OTP + rebar3
-        run: brew install erlang rebar3
+      - name: Install Erlang
+        run: brew install ${{matrix.brew_erlang}}
+      - name: Install rebar3
+        run: "mkdir rebar3 && curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3/rebar3 && chmod +x rebar3/rebar3"
       - name: Set up rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -79,9 +89,9 @@ jobs:
       - name: Assemble eqwalizer binary
         run: "cd eqwalizer && native-image -H:IncludeResources=application.conf --no-server --no-fallback -jar target/scala-2.13/eqwalizer.jar eqwalizer"
       - name: Test elp
-        run: "export ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo test --workspace"
+        run: "export PATH=$GITHUB_WORKSPACE/rebar3:/usr/local/opt/${{matrix.brew_erlang}}/bin:$PATH ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo test --workspace"
       - name: Assemble elp
-        run: "export ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo build --release"
+        run: "export PATH=$GITHUB_WORKSPACE/rebar3:/usr/local/opt/${{matrix.brew_erlang}}/bin:$PATH ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo build --release"
 name: eqWAlizer CI
 on:
   push: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,12 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: '25.2'
-          rebar3-version: '3.20.0'
+          install-rebar: false
+          install-hex: false
+      - name: Install rebar3
+        run: "curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3 && chmod +x rebar3"
+      - name: "add rebar3 to path"
+        run: 'echo "$GITHUB_WORKSPACE/rebar3" >> $GITHUB_PATH'
       - name: Assemble eqwalizer.jar
         run: "cd eqwalizer; sbt assembly"
       - name: Assemble eqwalizer binary
@@ -90,7 +95,12 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: '23.3'
-          rebar3-version: '3.20.0'
+          install-rebar: false
+          install-hex: false
+      - name: Install rebar3
+        run: "curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3 && chmod +x rebar3"
+      - name: "add rebar3 to path"
+        run: 'echo "$GITHUB_WORKSPACE/rebar3" >> $GITHUB_PATH'
       - name: Download eqwalizer.jar
         uses: "actions/download-artifact@v2"
         with:
@@ -121,7 +131,7 @@ jobs:
           asset_name: elp-linux-otp-23.tar.gz
           asset_path: elp-linux-otp-23.tar.gz
           upload_url: "${{ steps.get_release_url.outputs.upload_url }}"
-  macos-release:
+  macos-release-otp-25:
     needs:
       - linux-release-otp-25
     runs-on: macos-latest
@@ -135,8 +145,10 @@ jobs:
           java: 'java11'
       - name: Install Native Image Plugin
         run: gu install native-image
-      - name: Install erlang + rebar3
-        run: brew install erlang rebar3
+      - name: Install erlang
+        run: brew install erlang@25
+      - name: Install rebar3
+        run: "mkdir rebar3 && curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3/rebar3 && chmod +x rebar3/rebar3"
       - name: Set up rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -149,9 +161,9 @@ jobs:
       - name: Assemble eqwalizer binary
         run: "cd eqwalizer && native-image -H:IncludeResources=application.conf --no-server --no-fallback -jar target/scala-2.13/eqwalizer.jar eqwalizer"
       - name: Test elp
-        run: "export ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo test --workspace"
+        run: "export PATH=$GITHUB_WORKSPACE/rebar3:/usr/local/opt/erlang@25/bin:$PATH ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo test --workspace"
       - name: Assemble elp
-        run: "export ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo build --release"
+        run: "export PATH=$GITHUB_WORKSPACE/rebar3:/usr/local/opt/erlang@25/bin:$PATH ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo build --release"
       - name: Make elp-macos.tar.gz
         run: 'tar -zcvf elp-macos.tar.gz -C mini-elp/target/release/ elp'
       - env:
@@ -167,6 +179,55 @@ jobs:
           asset_content_type: application/octet-stream
           asset_name: elp-macos.tar.gz
           asset_path: elp-macos.tar.gz
+          upload_url: "${{ steps.get_release_url.outputs.upload_url }}"
+  macos-release-otp-23:
+    needs:
+      - linux-release-otp-25
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: "actions/checkout@v2"
+      - name: Set up GraalVM
+        uses: "DeLaGuardo/setup-graalvm@5.0"
+        with:
+          graalvm: '22.1.0'
+          java: 'java11'
+      - name: Install Native Image Plugin
+        run: gu install native-image
+      - name: Install erlang
+        run: brew install erlang@23
+      - name: Install rebar3
+        run: "mkdir rebar3 && curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3/rebar3 && chmod +x rebar3/rebar3"
+      - name: Set up rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Download eqwalizer.jar
+        uses: "actions/download-artifact@v2"
+        with:
+          name: eqwalizer.jar
+          path: eqwalizer/target/scala-2.13
+      - name: Assemble eqwalizer binary
+        run: "cd eqwalizer && native-image -H:IncludeResources=application.conf --no-server --no-fallback -jar target/scala-2.13/eqwalizer.jar eqwalizer"
+      - name: Test elp
+        run: "export PATH=$GITHUB_WORKSPACE/rebar3:/usr/local/opt/erlang@23/bin:$PATH ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo test --workspace"
+      - name: Assemble elp
+        run: "export PATH=$GITHUB_WORKSPACE/rebar3:/usr/local/opt/erlang@23/bin:$PATH ELP_EQWALIZER_PATH=$GITHUB_WORKSPACE/eqwalizer/eqwalizer && cd mini-elp && cargo build --release"
+      - name: Make elp-macos-otp-23.tar.gz
+        run: 'tar -zcvf elp-macos-otp-23.tar.gz -C mini-elp/target/release/ elp'
+      - env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        id: get_release_url
+        name: Get release url
+        uses: "bruceadams/get-release@v1.3.2"
+      - env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        name: Upload release elp-macos-otp-23.tar.gz
+        uses: "actions/upload-release-asset@v1.0.2"
+        with:
+          asset_content_type: application/octet-stream
+          asset_name: elp-macos-otp-23.tar.gz
+          asset_path: elp-macos-otp-23.tar.gz
           upload_url: "${{ steps.get_release_url.outputs.upload_url }}"
 name: eqWAlizer release
 on:


### PR DESCRIPTION
- downloading rebar3 from https://s3.amazonaws.com/rebar3/rebar3
- ugly `export PATH=...` in Mac actions - after a dozen attempts I were not able to work it with `$GITHUB_PATH` for MacOS workers
- adding one more release with OTP 23 on mac
- testing: https://github.com/ilya-klyuchnikov/eqwalizer/releases/tag/otp-23-mac