### PR TITLE
GH CI: actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         otp: ['26.0', '25.3', '24.3']
     steps:
       - name: Checkout
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
@@ -61,7 +61,7 @@ jobs:
         brew_erlang: ['erlang@25', 'erlang@24']
     steps:
       - name: Checkout
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
@@ -135,7 +135,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
@@ -181,7 +181,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:


### PR DESCRIPTION
This finally eliminates GH actions warnings about nodejs 12/16 migration