### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/eqwalizer/src/main/java/com/ericsson/otp/erlang/OtpErlangList.java
+++ b/eqwalizer/src/main/java/com/ericsson/otp/erlang/OtpErlangList.java
@@ -334,7 +334,9 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     return new Itr(start);
   }
 
-  /** @return true if the list is proper, i.e. the last tail is nil */
+  /**
+   * @return true if the list is proper, i.e. the last tail is nil
+   */
   public boolean isProper() {
     return lastTail == null;
   }

--- a/eqwalizer/src/main/java/com/ericsson/otp/erlang/OtpInputStream.java
+++ b/eqwalizer/src/main/java/com/ericsson/otp/erlang/OtpInputStream.java
@@ -41,7 +41,9 @@ public class OtpInputStream extends ByteArrayInputStream {
 
   private final int flags;
 
-  /** @param buf */
+  /**
+   * @param buf
+   */
   public OtpInputStream(final byte[] buf) {
     this(buf, 0);
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/screenshot-tests-for-android/pull/324

X-link: https://github.com/facebook/mariana-trench/pull/153

X-link: https://github.com/facebook/hermes/pull/1290

X-link: https://github.com/facebook/TextLayoutBuilder/pull/35

X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


