### PR TITLE
Update READMEs for eqWAlizer move into ELP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A type-checker for Erlang.
 
+> [!IMPORTANT]
+> The eqWAlizer repository is moving into [ELP (Erlang Language Platform)](https://github.com/whatsapp/erlang-language-platform).
+> Please use the [erlang-language-platform](https://github.com/whatsapp/erlang-language-platform) repository for issues and pull requests.
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./logo/eqWAlizer_final_Full_Logo_White_Text.png">
   <img alt="eqWAlizer logo" src="./logo/eqWAlizer_final_Full__Logo_Black_Text.png" width="100%">
@@ -26,9 +30,9 @@ Adding `eqwalizer_support`:
 {deps, [
   {eqwalizer_support,
     {git_subdir,
-        "https://github.com/whatsapp/eqwalizer.git",
+        "https://github.com/whatsapp/erlang-language-platform.git",
         {branch, "main"},
-        "eqwalizer_support"}}
+        "eqwalizer/eqwalizer_support"}}
 ]}.
 ```
 


### PR DESCRIPTION
Summary:
The eqWAlizer repository is moving into the ELP (Erlang Language Platform) repository. This updates the relevant documentation:

- `eqwalizer/README.md`: Update the `eqwalizer_support` dependency snippet to point at `https://github.com/whatsapp/erlang-language-platform.git` with the `eqwalizer/eqwalizer_support` subdir, and add an `[!IMPORTANT]` admonition at the top directing issues and pull requests to the `erlang-language-platform` repository.
- `elp/README.md`: Expand the description to explain that ELP includes eqWAlizer (with a one-line summary of what it is) and link to the eqWAlizer README, add a small eqWAlizer logo, and shrink the ELP logo to render at 60% width.

Differential Revision: D109806596


